### PR TITLE
`password`のデフォルトを空にする

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -32,7 +32,7 @@
                   <span class="input-group-text"><i class="ni ni-lock-circle-open"></i></span>
                 </div>
                 <input class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" name="password"
-                  placeholder="{{ __('Password') }}" type="password" value="secret" required>
+                  placeholder="{{ __('Password') }}" type="password" required>
               </div>
               @if ($errors->has('password'))
               <span class="invalid-feedback" style="display: block;" role="alert">


### PR DESCRIPTION
## 実装
ログインページで`password`のデフォルトを空にする 

## issue
ログインページで`password`のデフォルトを空にする #258

close #258